### PR TITLE
Fixed volume bar color in colored variants

### DIFF
--- a/src/_sass/gnome-shell/_common.scss
+++ b/src/_sass/gnome-shell/_common.scss
@@ -719,7 +719,7 @@ StScrollBar {
     // FIXME: above 'background-color' property rendered correct trough
     // colour already, so keep -background-color style-property transparent
     -barlevel-background-color: transparent;
-    -barlevel-active-background-color: $success_color;
+    -barlevel-active-background-color: $primary_color;
     -barlevel-overdrive-color: $destructive_color;
     -barlevel-overdrive-separator-width: 2px;
     -barlevel-border-width: 0;


### PR DESCRIPTION
When using one of the non green variants the volume bar slider was still green since it used $success_color instead of $primary_color