### PR TITLE
Fix popup in gnome shell 3.36

### DIFF
--- a/src/gnome-shell/gnome-shell-blue-compact.css
+++ b/src/gnome-shell/gnome-shell-blue-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-blue-dark-compact.css
+++ b/src/gnome-shell/gnome-shell-blue-dark-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-blue-dark.css
+++ b/src/gnome-shell/gnome-shell-blue-dark.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-blue-light-compact.css
+++ b/src/gnome-shell/gnome-shell-blue-light-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-blue-light.css
+++ b/src/gnome-shell/gnome-shell-blue-light.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-blue.css
+++ b/src/gnome-shell/gnome-shell-blue.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-compact.css
+++ b/src/gnome-shell/gnome-shell-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-dark-compact.css
+++ b/src/gnome-shell/gnome-shell-dark-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-dark.css
+++ b/src/gnome-shell/gnome-shell-dark.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo-compact.css
+++ b/src/gnome-shell/gnome-shell-indigo-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo-dark-compact.css
+++ b/src/gnome-shell/gnome-shell-indigo-dark-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo-dark.css
+++ b/src/gnome-shell/gnome-shell-indigo-dark.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo-light-compact.css
+++ b/src/gnome-shell/gnome-shell-indigo-light-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo-light.css
+++ b/src/gnome-shell/gnome-shell-indigo-light.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-indigo.css
+++ b/src/gnome-shell/gnome-shell-indigo.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-light-compact.css
+++ b/src/gnome-shell/gnome-shell-light-compact.css
@@ -1217,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1224,8 +1226,6 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .datemenu-displays-box,
 .message-list-sections {
   margin: 0 8px;
-  border-color: transparent;
-  background-color: transparent;
 }
 
 .datemenu-calendar-column {

--- a/src/gnome-shell/gnome-shell-light-compact.css
+++ b/src/gnome-shell/gnome-shell-light-compact.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1219,6 +1224,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 .datemenu-displays-box,
 .message-list-sections {
   margin: 0 8px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-calendar-column {
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell-light.css
+++ b/src/gnome-shell/gnome-shell-light.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {

--- a/src/gnome-shell/gnome-shell.css
+++ b/src/gnome-shell/gnome-shell.css
@@ -860,6 +860,11 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   border-bottom-style: solid;
 }
 
+.popup-separator-menu-item-separator {
+  background-color: transparent;
+  border-color: transparent;
+}
+
 .background-menu {
   -boxpointer-gap: 4px;
   -arrow-rise: 0;
@@ -1212,6 +1217,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
 
 .calendar {
   margin-bottom: 0;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .calendar,
@@ -1252,6 +1259,8 @@ StScrollBar StButton#vhandle:active, StScrollBar StButton#hhandle:active {
   min-height: 20px;
   padding: 4px 8px;
   border-radius: 6px;
+  border-color: transparent;
+  background-color: transparent;
 }
 
 .datemenu-today-button {


### PR DESCRIPTION
This branch fixes issues in gnome shell popups, in particular it removes duplicate separators and the default theme from calendar and buttons below